### PR TITLE
Implement LZX support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "cab"
 version = "0.2.0"
+edition = '2018'
 authors = ["Matthew D. Steele <mdsteele@alum.mit.edu>"]
 description = "Read/write Windows cabinet (CAB) files"
 repository = "https://github.com/mdsteele/rust-cab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ chrono = "0.4"
 flate2 = { version = "1", features = ["rust_backend"], default-features = false }
 
 [dev-dependencies]
+anyhow = "1.0.43"
 clap = "2.27"
 lipsum = "0.6"
 rand = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 byteorder = "1"
 chrono = "0.4"
 flate2 = { version = "1", features = ["rust_backend"], default-features = false }
+lzxd = "0.1.1"
 
 [dev-dependencies]
 anyhow = "1.0.43"

--- a/examples/cabtool.rs
+++ b/examples/cabtool.rs
@@ -146,7 +146,7 @@ fn list_file(folder_index: usize, folder: &FolderEntry, file: &FileEntry,
              folder_index,
              ctype,
              file_size,
-             file.datetime(),
+             file.datetime().map(|dt| dt.to_string()).unwrap_or("invalid datetime".to_string()),
              file.name());
 }
 

--- a/examples/readcab.rs
+++ b/examples/readcab.rs
@@ -1,20 +1,22 @@
 extern crate cab;
 
+use anyhow::Context;
+
 use std::env;
 use std::fs::File;
 use std::path::Path;
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     let num_args = env::args().count();
     if num_args != 2 {
         println!("Usage: readcab <path/to/archive.cab>");
-        return;
+        return Ok(());
     }
 
     let input_path = env::args().nth(1).unwrap();
     let input_path = Path::new(&input_path);
-    let input_file = File::open(input_path).unwrap();
-    let cabinet = cab::Cabinet::new(input_file).unwrap();
+    let input_file = File::open(input_path)?;
+    let cabinet = cab::Cabinet::new(input_file).context("Failed to open cabinet file")?;
     for (index, folder) in cabinet.folder_entries().enumerate() {
         println!("Folder #{}:", index);
         println!("  compression_type = {:?}", folder.compression_type());
@@ -28,4 +30,6 @@ fn main() {
         }
         println!("  {} bytes total", total_size);
     }
+
+    Ok(())
 }

--- a/src/internal/builder.rs
+++ b/src/internal/builder.rs
@@ -1,10 +1,10 @@
 use byteorder::{LittleEndian, WriteBytesExt};
 use chrono::{Local, NaiveDateTime};
-use internal::checksum::Checksum;
-use internal::consts;
-use internal::ctype::CompressionType;
-use internal::datetime::datetime_to_bits;
-use internal::mszip::MsZipCompressor;
+use crate::internal::checksum::Checksum;
+use crate::internal::consts;
+use crate::internal::ctype::CompressionType;
+use crate::internal::datetime::datetime_to_bits;
+use crate::internal::mszip::MsZipCompressor;
 use std::io::{self, Seek, SeekFrom, Write};
 use std::mem;
 use std::u16;
@@ -600,7 +600,7 @@ impl<W: Write + Seek> Write for FolderWriter<W> {
 mod tests {
     use super::CabinetBuilder;
     use chrono::NaiveDate;
-    use internal::ctype::CompressionType;
+    use crate::internal::ctype::CompressionType;
     use std::io::{Cursor, Write};
 
     #[test]

--- a/src/internal/cabinet.rs
+++ b/src/internal/cabinet.rs
@@ -1,10 +1,10 @@
 use byteorder::{LittleEndian, ReadBytesExt};
 use chrono::NaiveDateTime;
-use internal::checksum::Checksum;
-use internal::consts;
-use internal::ctype::CompressionType;
-use internal::datetime::datetime_from_bits;
-use internal::mszip::MsZipDecompressor;
+use crate::internal::checksum::Checksum;
+use crate::internal::consts;
+use crate::internal::ctype::CompressionType;
+use crate::internal::datetime::datetime_from_bits;
+use crate::internal::mszip::MsZipDecompressor;
 use std::io::{self, Read, Seek, SeekFrom};
 use std::slice;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,10 +94,10 @@ extern crate flate2;
 
 mod internal;
 
-pub use internal::builder::{CabinetBuilder, CabinetWriter, FileBuilder,
+pub use crate::internal::builder::{CabinetBuilder, CabinetWriter, FileBuilder,
                             FileWriter, FolderBuilder};
-pub use internal::cabinet::{Cabinet, FileEntries, FileEntry, FileReader,
+pub use crate::internal::cabinet::{Cabinet, FileEntries, FileEntry, FileReader,
                             FolderEntries, FolderEntry};
-pub use internal::ctype::CompressionType;
+pub use crate::internal::ctype::CompressionType;
 
 // ========================================================================= //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,12 +12,12 @@
 //! metadata for an existing cabinet file, but currently only supports
 //! encoding/decoding some of them, as shown:
 //!
-//! | Compression                                                 | Supported |
-//! |-------------------------------------------------------------|-----------|
-//! | Uncompressed                                                | Yes       |
-//! | MSZIP ([Deflate](https://en.wikipedia.org/wiki/DEFLATE))    | Yes       |
-//! | [Quantum](https://en.wikipedia.org/wiki/Quantum_compression)| No        |
-//! | [LZX](https://en.wikipedia.org/wiki/LZX_(algorithm))        | No        |
+//! | Compression                                                 | Supported         |
+//! |-------------------------------------------------------------|-------------------|
+//! | Uncompressed                                                | Yes               |
+//! | MSZIP ([Deflate](https://en.wikipedia.org/wiki/DEFLATE))    | Yes               |
+//! | [Quantum](https://en.wikipedia.org/wiki/Quantum_compression)| No                |
+//! | [LZX](https://en.wikipedia.org/wiki/LZX_(algorithm))        | Yes (decode only) |
 //!
 //! # Example usage
 //!

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -33,7 +33,7 @@ fn cabinet_with_one_small_uncompressed_text_file() {
     let mut cabinet = cab::Cabinet::new(Cursor::new(cab_file)).unwrap();
     {
         let file_entry = cabinet.get_file_entry("lorem_ipsum.txt").unwrap();
-        assert_eq!(file_entry.datetime(), datetime);
+        assert_eq!(file_entry.datetime(), Some(datetime));
         assert!(file_entry.is_read_only());
         assert!(!file_entry.is_hidden());
         assert!(file_entry.is_system());


### PR DESCRIPTION
This is a set of changes to implement LZX decompression support, as well as a few other misc. improvements:

* Upgrade to Rust 2018
* Use `anyhow` to report errors from `readcab`.
* Ignore an invalid datetime field in a cabinet file (encountered in the wild).

Note that this changeset depends on Lonami/lzxd#4, and the test I've added won't succeed until that pull request is merged upstream.

This PR fixes #7.