### PR TITLE
Replace chrono with time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ readme = "README.md"
 
 [dependencies]
 byteorder = "1"
-time = "0.3"
 flate2 = { version = "1", features = [
     "rust_backend",
 ], default-features = false }
 lzxd = "0.1.4"
+time = "0.3"
 
 [dev-dependencies]
 anyhow = "1.0.43"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,16 @@ readme = "README.md"
 
 [dependencies]
 byteorder = "1"
-chrono = "0.4"
-flate2 = { version = "1", features = ["rust_backend"], default-features = false }
+time = "0.3"
+flate2 = { version = "1", features = [
+    "rust_backend",
+], default-features = false }
 lzxd = "0.1.4"
 
 [dev-dependencies]
 anyhow = "1.0.43"
 clap = "2.27"
-lipsum = "0.6"
-rand = "0.3"
-winapi = "0.2"
+lipsum = "0.8"
+rand = { version = "0.8", features = ["small_rng"] }
+time = { version = "0.3", features = ["macros"] }
+winapi = { version = "0.3", features = ["basetsd", "minwindef", "winnt"] }

--- a/examples/cabtool.rs
+++ b/examples/cabtool.rs
@@ -1,14 +1,10 @@
-extern crate cab;
-extern crate chrono;
-extern crate clap;
-
 use cab::{Cabinet, CabinetBuilder, CompressionType, FileEntry, FolderEntry};
-use chrono::NaiveDateTime;
 use clap::{App, Arg, SubCommand};
 use std::fs::{self, File};
 use std::io;
 use std::path::PathBuf;
 use std::time::UNIX_EPOCH;
+use time::{OffsetDateTime, PrimitiveDateTime};
 
 // ========================================================================= //
 
@@ -100,9 +96,14 @@ fn main() {
                     let file = folder.add_file(filename);
                     if let Ok(time) = metadata.modified() {
                         if let Ok(dur) = time.duration_since(UNIX_EPOCH) {
-                            let secs = dur.as_secs() as i64;
-                            let ndt = NaiveDateTime::from_timestamp(secs, 0);
-                            file.set_datetime(ndt);
+                            let dt = OffsetDateTime::from_unix_timestamp(
+                                dur.as_secs() as i64,
+                            )
+                            .unwrap();
+                            file.set_datetime(PrimitiveDateTime::new(
+                                dt.date(),
+                                dt.time(),
+                            ));
                         }
                     }
                     file_index += 1;

--- a/src/internal/cabinet.rs
+++ b/src/internal/cabinet.rs
@@ -4,10 +4,10 @@ use crate::internal::ctype::CompressionType;
 use crate::internal::datetime::datetime_from_bits;
 use crate::internal::mszip::MsZipDecompressor;
 use byteorder::{LittleEndian, ReadBytesExt};
-use chrono::NaiveDateTime;
 use lzxd::Lzxd;
 use std::io::{self, Read, Seek, SeekFrom};
 use std::slice;
+use time::PrimitiveDateTime;
 
 // ========================================================================= //
 
@@ -296,7 +296,7 @@ impl<'a> ExactSizeIterator for FileEntries<'a> {}
 /// Metadata about one file stored in a cabinet.
 pub struct FileEntry {
     name: String,
-    datetime: Option<NaiveDateTime>,
+    datetime: Option<PrimitiveDateTime>,
     uncompressed_size: u32,
     uncompressed_offset: u32,
     attributes: u16,
@@ -314,7 +314,7 @@ impl FileEntry {
     ///
     /// Note that this will return [`None`] if the datetime in the cabinet file
     /// was not a valid date/time.
-    pub fn datetime(&self) -> Option<NaiveDateTime> {
+    pub fn datetime(&self) -> Option<PrimitiveDateTime> {
         self.datetime
     }
 
@@ -639,7 +639,6 @@ fn read_null_terminated_string<R: Read>(
 #[cfg(test)]
 mod tests {
     use super::Cabinet;
-    use chrono::{Datelike, Timelike};
     use std::io::{Cursor, Read};
 
     #[test]
@@ -662,7 +661,7 @@ mod tests {
             let dt = file.datetime().unwrap();
 
             assert_eq!(dt.year(), 1997);
-            assert_eq!(dt.month(), 3);
+            assert_eq!(dt.month(), time::Month::March);
             assert_eq!(dt.day(), 12);
             assert_eq!(dt.hour(), 11);
             assert_eq!(dt.minute(), 13);

--- a/src/internal/mszip.rs
+++ b/src/internal/mszip.rs
@@ -141,8 +141,8 @@ impl MsZipDecompressor {
 
 #[cfg(test)]
 mod tests {
-    extern crate rand;
-    use self::rand::Rng;
+    use rand::RngCore;
+
     use super::{MsZipCompressor, MsZipDecompressor, DEFLATE_MAX_DICT_LEN};
 
     #[test]
@@ -169,7 +169,11 @@ mod tests {
     }
 
     fn random_data(size: usize) -> Vec<u8> {
-        rand::thread_rng().gen_iter::<u8>().take(size).collect()
+        use rand::SeedableRng;
+
+        let mut rd = vec![0; size];
+        rand::rngs::SmallRng::from_entropy().fill_bytes(&mut rd);
+        rd
     }
 
     #[cfg(target_env = "msvc")]
@@ -179,8 +183,6 @@ mod tests {
     /// sharing it.
     mod sys {
         #![allow(non_camel_case_types)]
-
-        extern crate winapi;
 
         use self::winapi::basetsd::{PSIZE_T, SIZE_T};
         use self::winapi::minwindef::{BOOL, DWORD, FALSE, LPVOID, TRUE};

--- a/src/internal/mszip.rs
+++ b/src/internal/mszip.rs
@@ -184,12 +184,12 @@ mod tests {
     mod sys {
         #![allow(non_camel_case_types)]
 
-        use self::winapi::basetsd::{PSIZE_T, SIZE_T};
-        use self::winapi::minwindef::{BOOL, DWORD, FALSE, LPVOID, TRUE};
-        use self::winapi::winnt::{HANDLE, PVOID};
         use super::super::DEFLATE_MAX_DICT_LEN;
         use std::mem;
         use std::ptr;
+        use winapi::shared::basetsd::{PSIZE_T, SIZE_T};
+        use winapi::shared::minwindef::{BOOL, DWORD, FALSE, LPVOID, TRUE};
+        use winapi::um::winnt::{HANDLE, PVOID};
 
         const COMPRESS_ALGORITHM_MSZIP: DWORD = 2;
         const COMPRESS_RAW: DWORD = 1 << 29;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,6 @@
 #![warn(missing_docs)]
 
 extern crate byteorder;
-extern crate chrono;
 extern crate flate2;
 
 mod internal;

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -1,18 +1,12 @@
-extern crate cab;
-extern crate chrono;
-extern crate lipsum;
-extern crate rand;
-
-use chrono::NaiveDate;
-use rand::Rng;
 use std::io::{Cursor, Read, Write};
+use time::macros::datetime;
 
 // ========================================================================= //
 
 #[test]
 fn cabinet_with_one_small_uncompressed_text_file() {
     let original = lipsum::lipsum(500);
-    let datetime = NaiveDate::from_ymd(2063, 4, 5).and_hms(23, 14, 38);
+    let datetime = datetime!(2063-04-05 23:14:38);
 
     let mut cab_builder = cab::CabinetBuilder::new();
     {
@@ -132,8 +126,10 @@ fn cabinet_with_one_big_mszipped_text_file() {
 // ========================================================================= //
 
 fn random_data_roundtrip(num_bytes: usize, ctype: cab::CompressionType) {
-    let original: Vec<u8> =
-        rand::thread_rng().gen_iter::<u8>().take(num_bytes).collect();
+    use rand::{RngCore, SeedableRng};
+
+    let mut original = vec![0; num_bytes];
+    rand::rngs::SmallRng::from_entropy().fill_bytes(&mut original);
 
     let mut cab_builder = cab::CabinetBuilder::new();
     cab_builder.add_folder(ctype).add_file("binary");


### PR DESCRIPTION
This PR fixes 2 security advisories

- https://rustsec.org/advisories/RUSTSEC-2020-0159.html
- https://rustsec.org/advisories/RUSTSEC-2020-0071.html

These are both caused by `chrono`, as one is directly on `chrono`, and the other is due to it having a dependency on an ancient version of `time` which has a similar advisory that has been fixed in later versions. `chrono` is essentially unmaintained and has not seen a release in almost 2 years and the `time` crate includes all of the functionality needed by this crate. Thanks to the tests it was easy to use `time` instead and verify it works since this crate wasn't using any chrono features that don't have exact parallels in time, namely format strings.

This is however a breaking change since `chrono` was part of the public API, but I don't think it will be disruptive to users. One behavior change however was also needed in `FileBuilder` as it was using local time as the default value if not set by the user. Use of local time on unix platforms (not Windows) was the root cause of both of the above advisories. Unfortunately, the way the time crate worked around this deficiency of local time was to actually check the number of active threads at runtime to ensure there was only 1 thread running, _or_ require that the user use `--cfg unsound_local_offset` at build time to opt-in to the unsound use of local time. Both of these restrictions are IMO unacceptable as they severely restrict downstream usage, so the introduced behavior change is that the default is now no longer local time, but UTC time. I considered this fine since, as the comment on `set_datetime` states, the CAB spec says "the actual definition is application-defined", and IMO UTC time is superior since it is consistent for every reader and writer, as, presumably, the local offset would need to be communicated in some way as otherwise a reader in a different time offset would get an incorrect time if it is assumed to be local.

This also updates some outdated dev-dependencies, namely `winapi`, as `winapi` 0.3 uses feature flags for all of the functionality in the crate now, so this only enables the few used by the tests, which _should_ give noticeable improvements to build times. FWIW `windows-sys` includes the functions that are manually bound in the tests (eg [CreateCompressor](https://docs.rs/windows-sys/0.36.1/windows_sys/Win32/Storage/Compression/fn.CreateCompressor.html)), but given this crate already works, and `windows-sys` has some [issues](https://github.com/microsoft/windows-rs/issues/1720) I figured it was better to just bump `winapi` instead of replacing it.