### PR TITLE
feat: Less allocations

### DIFF
--- a/examples/cabtool.rs
+++ b/examples/cabtool.rs
@@ -104,7 +104,7 @@ fn main() {
             let cabinet = Cabinet::new(File::open(path).unwrap()).unwrap();
             for (index, folder) in cabinet.folder_entries().enumerate() {
                 for file in folder.file_entries() {
-                    list_file(index, folder, file, long);
+                    list_file(index, &folder, file, long);
                 }
             }
         }


### PR DESCRIPTION
Depends on: https://github.com/mdsteele/rust-cab/pull/18
Part of: https://github.com/mdsteele/rust-cab/pull/16

## Changes:

1. Moved `files` from `FolderEntry` to `Cabinet` 
2. Reduced the number of allocations
3. Reduced the complexity of the search files by filename