### PR TITLE
Feature/cabinet inner

### DIFF
--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -1,4 +1,3 @@
-//use chrono::{Datelike, Duration, NaiveDate, NaiveDateTime, Timelike};
 use std::convert::TryInto;
 
 use time::PrimitiveDateTime;


### PR DESCRIPTION
This is continue of: https://github.com/mdsteele/rust-cab/pull/22. 

I moved `Cabinet` fields into `struct CabinetInner`. I need it to win over BorrowChecker)