### PR TITLE
fix: Fixed bug with unsorted files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ readme = "README.md"
 [dependencies]
 byteorder = "1"
 flate2 = { version = "1", features = ["rust_backend"], default-features = false }
-lzxd = "0.2"
+lzxd = "0.2.5"
 time = "0.3"
 
 [dev-dependencies]
 anyhow = "1.0"
-lipsum = "0.8"
-clap = { version = "4.1", features = ["color", "suggestions", "derive", "wrap_help", "unicode"] }
+lipsum = "0.9"
+clap = { version = "4.4", features = ["color", "suggestions", "derive", "wrap_help", "unicode"] }
 rand = { version = "0.8", features = ["small_rng"] }
 time = { version = "0.3", features = ["macros"] }
 winapi = { version = "0.3", features = ["basetsd", "minwindef", "winnt"] }


### PR DESCRIPTION
@mdsteele hello! I found a bug. The specification says:

```
The CFFILE structure entries in a cabinet are ordered by iFolder field value...
```

I found an example where this is not true. Utilities like gcab and cabextract work with this. This will fixed it.
