### PR TITLE
feat: get the name as a  byte vector

### DIFF
--- a/src/cabinet.rs
+++ b/src/cabinet.rs
@@ -78,15 +78,15 @@ impl<R: Read + Seek> Cabinet<R> {
             reader.read_exact(&mut header_reserve_data)?;
         }
         let _prev_cabinet = if (flags & consts::FLAG_PREV_CABINET) != 0 {
-            let cab_name = read_null_terminated_string(&mut reader, false)?;
-            let disk_name = read_null_terminated_string(&mut reader, false)?;
+            let (_,cab_name) = read_null_terminated_string(&mut reader, false)?;
+            let (_,disk_name) = read_null_terminated_string(&mut reader, false)?;
             Some((cab_name, disk_name))
         } else {
             None
         };
         let _next_cabinet = if (flags & consts::FLAG_NEXT_CABINET) != 0 {
-            let cab_name = read_null_terminated_string(&mut reader, false)?;
-            let disk_name = read_null_terminated_string(&mut reader, false)?;
+            let (_,cab_name) = read_null_terminated_string(&mut reader, false)?;
+            let (_,disk_name) = read_null_terminated_string(&mut reader, false)?;
             Some((cab_name, disk_name))
         } else {
             None

--- a/src/cabinet.rs
+++ b/src/cabinet.rs
@@ -78,15 +78,19 @@ impl<R: Read + Seek> Cabinet<R> {
             reader.read_exact(&mut header_reserve_data)?;
         }
         let _prev_cabinet = if (flags & consts::FLAG_PREV_CABINET) != 0 {
-            let (cab_name,_) = read_null_terminated_string(&mut reader, false)?;
-            let (disk_name,_) = read_null_terminated_string(&mut reader, false)?;
+            let (cab_name, _) =
+                read_null_terminated_string(&mut reader, false)?;
+            let (disk_name, _) =
+                read_null_terminated_string(&mut reader, false)?;
             Some((cab_name, disk_name))
         } else {
             None
         };
         let _next_cabinet = if (flags & consts::FLAG_NEXT_CABINET) != 0 {
-            let (cab_name,_) = read_null_terminated_string(&mut reader, false)?;
-            let (disk_name,_) = read_null_terminated_string(&mut reader, false)?;
+            let (cab_name, _) =
+                read_null_terminated_string(&mut reader, false)?;
+            let (disk_name, _) =
+                read_null_terminated_string(&mut reader, false)?;
             Some((cab_name, disk_name))
         } else {
             None

--- a/src/cabinet.rs
+++ b/src/cabinet.rs
@@ -78,15 +78,15 @@ impl<R: Read + Seek> Cabinet<R> {
             reader.read_exact(&mut header_reserve_data)?;
         }
         let _prev_cabinet = if (flags & consts::FLAG_PREV_CABINET) != 0 {
-            let (_,cab_name) = read_null_terminated_string(&mut reader, false)?;
-            let (_,disk_name) = read_null_terminated_string(&mut reader, false)?;
+            let (cab_name,_) = read_null_terminated_string(&mut reader, false)?;
+            let (disk_name,_) = read_null_terminated_string(&mut reader, false)?;
             Some((cab_name, disk_name))
         } else {
             None
         };
         let _next_cabinet = if (flags & consts::FLAG_NEXT_CABINET) != 0 {
-            let (_,cab_name) = read_null_terminated_string(&mut reader, false)?;
-            let (_,disk_name) = read_null_terminated_string(&mut reader, false)?;
+            let (cab_name,_) = read_null_terminated_string(&mut reader, false)?;
+            let (disk_name,_) = read_null_terminated_string(&mut reader, false)?;
             Some((cab_name, disk_name))
         } else {
             None

--- a/src/ctype.rs
+++ b/src/ctype.rs
@@ -75,9 +75,9 @@ impl CompressionType {
             CompressionType::MsZip => CTYPE_MSZIP,
             CompressionType::Quantum(level, memory) => {
                 CTYPE_QUANTUM
-                    | (level.max(QUANTUM_LEVEL_MIN).min(QUANTUM_LEVEL_MAX)
+                    | (level.clamp(QUANTUM_LEVEL_MIN,QUANTUM_LEVEL_MAX)
                         << 4)
-                    | (memory.max(QUANTUM_MEMORY_MIN).min(QUANTUM_MEMORY_MAX)
+                    | (memory.clamp(QUANTUM_MEMORY_MIN,QUANTUM_MEMORY_MAX)
                         << 8)
             }
             CompressionType::Lzx(window_size) => {

--- a/src/ctype.rs
+++ b/src/ctype.rs
@@ -75,9 +75,8 @@ impl CompressionType {
             CompressionType::MsZip => CTYPE_MSZIP,
             CompressionType::Quantum(level, memory) => {
                 CTYPE_QUANTUM
-                    | (level.clamp(QUANTUM_LEVEL_MIN,QUANTUM_LEVEL_MAX)
-                        << 4)
-                    | (memory.clamp(QUANTUM_MEMORY_MIN,QUANTUM_MEMORY_MAX)
+                    | (level.clamp(QUANTUM_LEVEL_MIN, QUANTUM_LEVEL_MAX) << 4)
+                    | (memory.clamp(QUANTUM_MEMORY_MIN, QUANTUM_MEMORY_MAX)
                         << 8)
             }
             CompressionType::Lzx(window_size) => {

--- a/src/file.rs
+++ b/src/file.rs
@@ -19,6 +19,7 @@ pub struct FileEntries<'a> {
 #[derive(Debug, Clone)]
 pub struct FileEntry {
     name: String,
+    name_raw: Vec<u8>,
     datetime: Option<PrimitiveDateTime>,
     uncompressed_size: u32,
     attributes: u16,
@@ -52,6 +53,11 @@ impl FileEntry {
     /// Returns the name of file.
     pub fn name(&self) -> &str {
         &self.name
+    }
+
+    /// Returns the name of file as a byte slice, useful if the string is not utf-8.
+    pub fn name_raw(&self) -> &Vec<u8> {
+        &self.name_raw
     }
 
     /// Returns the datetime for this file.  According to the CAB spec, this
@@ -150,9 +156,10 @@ pub(crate) fn parse_file_entry<R: Read>(
     let datetime = datetime_from_bits(date, time);
     let attributes = reader.read_u16::<LittleEndian>()?;
     let is_utf8 = (attributes & consts::ATTR_NAME_IS_UTF) != 0;
-    let name = read_null_terminated_string(&mut reader, is_utf8)?;
+    let (name_raw,name) = read_null_terminated_string(&mut reader, is_utf8)?;
     let entry = FileEntry {
         name,
+        name_raw,
         folder_index,
         datetime,
         uncompressed_size,

--- a/src/file.rs
+++ b/src/file.rs
@@ -156,7 +156,7 @@ pub(crate) fn parse_file_entry<R: Read>(
     let datetime = datetime_from_bits(date, time);
     let attributes = reader.read_u16::<LittleEndian>()?;
     let is_utf8 = (attributes & consts::ATTR_NAME_IS_UTF) != 0;
-    let (name,name_raw) = read_null_terminated_string(&mut reader, is_utf8)?;
+    let (name, name_raw) = read_null_terminated_string(&mut reader, is_utf8)?;
     let entry = FileEntry {
         name,
         name_raw,

--- a/src/file.rs
+++ b/src/file.rs
@@ -56,7 +56,7 @@ impl FileEntry {
     }
 
     /// Returns the name of file as a byte slice, useful if the string is not utf-8.
-    pub fn name_raw(&self) -> &Vec<u8> {
+    pub fn name_raw(&self) -> &[u8] {
         &self.name_raw
     }
 
@@ -156,7 +156,7 @@ pub(crate) fn parse_file_entry<R: Read>(
     let datetime = datetime_from_bits(date, time);
     let attributes = reader.read_u16::<LittleEndian>()?;
     let is_utf8 = (attributes & consts::ATTR_NAME_IS_UTF) != 0;
-    let (name_raw,name) = read_null_terminated_string(&mut reader, is_utf8)?;
+    let (name,name_raw) = read_null_terminated_string(&mut reader, is_utf8)?;
     let entry = FileEntry {
         name,
         name_raw,

--- a/src/string.rs
+++ b/src/string.rs
@@ -7,7 +7,7 @@ use crate::consts;
 pub(crate) fn read_null_terminated_string<R: Read>(
     reader: &mut R,
     _is_utf8: bool,
-) -> io::Result<String> {
+) -> io::Result<(Vec<u8>, String)> {
     let mut bytes = Vec::<u8>::with_capacity(consts::MAX_STRING_SIZE);
     loop {
         let byte = reader.read_u8()?;
@@ -22,5 +22,5 @@ pub(crate) fn read_null_terminated_string<R: Read>(
         bytes.push(byte);
     }
     // TODO: Handle decoding differently depending on `_is_utf8`.
-    Ok(String::from_utf8_lossy(&bytes).to_string())
+    Ok((bytes.clone(),String::from_utf8_lossy(&bytes).to_string()))
 }

--- a/src/string.rs
+++ b/src/string.rs
@@ -7,7 +7,7 @@ use crate::consts;
 pub(crate) fn read_null_terminated_string<R: Read>(
     reader: &mut R,
     _is_utf8: bool,
-) -> io::Result<(Vec<u8>, String)> {
+) -> io::Result<(String, Vec<u8>)> {
     let mut bytes = Vec::<u8>::with_capacity(consts::MAX_STRING_SIZE);
     loop {
         let byte = reader.read_u8()?;
@@ -22,5 +22,5 @@ pub(crate) fn read_null_terminated_string<R: Read>(
         bytes.push(byte);
     }
     // TODO: Handle decoding differently depending on `_is_utf8`.
-    Ok((bytes.clone(),String::from_utf8_lossy(&bytes).to_string()))
+    Ok((String::from_utf8_lossy(&bytes).to_string(), bytes.clone()))
 }


### PR DESCRIPTION
This exposes the name as a byte array as well as a string in case the name is not utf-8, the user can then handle it as they want.