### PR TITLE
Add Cabinet::all_files, method to extract all files in an archive sequentially and efficiently

### DIFF
--- a/src/all_files.rs
+++ b/src/all_files.rs
@@ -1,0 +1,82 @@
+use std::io::{Read, Seek};
+
+use crate::{folder::FolderReader, Cabinet, FileEntry, FolderEntry};
+
+pub struct SingleFileReader<'a, 'b, R>
+where
+    R: Read + Seek + 'a,
+{
+    parent: &'b mut FileReaderState<'a, R>,
+}
+
+impl<'a, 'b, R> Read for SingleFileReader<'a, 'b, R>
+where
+    R: Read + Seek + 'a,
+{
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let limlen = buf.len().min(self.parent.remain as usize);
+        let lim_buf = &mut buf[0..limlen];
+        match self.parent.folder_reader.read(lim_buf) {
+            Ok(n) => {
+                self.parent.remain -= n as u64;
+                Ok(n)
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+
+pub struct AllFiles<'a, R> {
+    pub(crate) data_reserve_size: u8,
+    pub(crate) cabinet: &'a Cabinet<R>,
+    pub(crate) folder_stack: Vec<FolderEntry>,
+    pub(crate) files_stack: Vec<FileEntry>,
+    pub(crate) reader_state: Option<FileReaderState<'a, R>>,
+}
+pub(crate) struct FileReaderState<'a, R> {
+    pub(crate) folder_reader: FolderReader<'a, R>,
+    pub(crate) remain: u64,
+}
+
+/// this is the struct created by [`Cabinet::all_files`]
+impl<'a, R> AllFiles<'a, R>
+where
+    R: Read + Seek + 'a,
+{
+    pub fn next_file<'b>(
+        &'b mut self,
+    ) -> Option<(FileEntry, SingleFileReader<'a, 'b, R>)> {
+        if let Some(file_entry) = self.files_stack.pop() {
+            if let Some(ref mut sub) = self.reader_state {
+                if sub.remain > 0 {
+                    let mut taker = (&mut sub.folder_reader).take(sub.remain);
+                    let _ = std::io::copy(&mut taker, &mut std::io::sink());
+                }
+                sub.remain = file_entry.uncompressed_size() as u64;
+                Some((file_entry, SingleFileReader { parent: sub }))
+            } else {
+                None
+            }
+        } else {
+            match self.folder_stack.pop() {
+                Some(folder_entry) => {
+                    let folder_reader = FolderReader::new(
+                        self.cabinet,
+                        &folder_entry,
+                        self.data_reserve_size,
+                    )
+                    .ok()?;
+                    self.reader_state =
+                        Some(FileReaderState { folder_reader, remain: 0 });
+                    let files = folder_entry.files;
+                    let mut files_stack: Vec<_> = files.into_iter().collect();
+                    files_stack.sort_by_key(|f| f.uncompressed_offset);
+                    files_stack.reverse();
+                    self.files_stack = files_stack;
+                    self.next_file()
+                }
+                None => None,
+            }
+        }
+    }
+}

--- a/src/cabinet.rs
+++ b/src/cabinet.rs
@@ -3,6 +3,7 @@ use std::io::{self, Read, Seek, SeekFrom};
 
 use byteorder::{LittleEndian, ReadBytesExt};
 
+use crate::all_files::AllFiles;
 use crate::consts;
 use crate::file::{parse_file_entry, FileEntry, FileReader};
 use crate::folder::{
@@ -174,6 +175,42 @@ impl<R: Read + Seek> Cabinet<R> {
             }
 
             None => not_found!("No such file in cabinet: {:?}", name),
+        }
+    }
+
+    /// Returns `AllFiles` for sequential extraction of all files in the archive.
+    /// Example
+    /// ```rust
+    /// # use std::io::Cursor;
+    /// # use std::io::Read;
+    /// # use std::io::Write;
+    /// # let original_string = lipsum::lipsum(30000);
+    /// # let original_bytes = original_string.as_bytes();
+    /// # let mut cab_builder = cab::CabinetBuilder::new();
+    /// # cab_builder
+    /// #     .add_folder(cab::CompressionType::None)
+    /// #     .add_file("lorem_ipsum.txt");
+    /// # let mut cab_writer = cab_builder.build(Cursor::new(Vec::new())).unwrap();
+    /// # while let Some(mut file_writer) = cab_writer.next_file().unwrap() {
+    /// #     file_writer.write_all(original_bytes).unwrap();
+    /// # }
+    /// # let cab_file = cab_writer.finish().unwrap().into_inner();
+    /// # let mut cabinet = cab::Cabinet::new(Cursor::new(cab_file)).unwrap();
+    /// let mut all_files = cabinet.all_files();
+    /// while let Some((file_entry, mut file_reader)) = all_files.next_file() {
+    ///     println!("Extracting {}",file_entry.name());
+    ///     let mut buf = vec![];
+    ///     file_reader.read_to_end(&mut buf);
+    ///     println!("Extracted {} bytes.",buf.len());
+    /// }
+    /// ```
+    pub fn all_files<'a>(&'a self) -> AllFiles<'a, R> {
+        AllFiles {
+            data_reserve_size: self.inner.data_reserve_size,
+            folder_stack: self.inner.folders.clone(),
+            cabinet: self,
+            files_stack: vec![],
+            reader_state: None,
         }
     }
 

--- a/src/cabinet.rs
+++ b/src/cabinet.rs
@@ -233,13 +233,13 @@ impl<R: Read + Seek> Cabinet<R> {
     }
 }
 
-impl<'a, R: ?Sized + Read> Read for &'a CabinetInner<R> {
+impl<R: ?Sized + Read> Read for &CabinetInner<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.reader.borrow_mut().read(buf)
     }
 }
 
-impl<'a, R: ?Sized + Seek> Seek for &'a CabinetInner<R> {
+impl<R: ?Sized + Seek> Seek for &CabinetInner<R> {
     fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
         self.reader.borrow_mut().seek(pos)
     }

--- a/src/ctype.rs
+++ b/src/ctype.rs
@@ -138,11 +138,11 @@ impl Decompressor {
             Decompressor::Uncompressed => data,
             Decompressor::MsZip(decompressor) => decompressor
                 .decompress_block(&data, uncompressed_size)
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?
+                .map_err(io::Error::other)?
                 .to_vec(),
             Decompressor::Lzx(decompressor) => decompressor
                 .decompress_next(&data, uncompressed_size)
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?
+                .map_err(io::Error::other)?
                 .to_vec(),
         };
         Ok(data)

--- a/src/folder.rs
+++ b/src/folder.rs
@@ -16,6 +16,7 @@ pub struct FolderEntries<'a> {
 }
 
 /// Metadata about one folder in a cabinet.
+#[derive(Clone)]
 pub struct FolderEntry {
     first_data_block_offset: u32,
     num_data_blocks: u16,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,3 +115,4 @@ mod file;
 mod folder;
 mod mszip;
 mod string;
+mod all_files;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,7 @@ pub use folder::{FolderEntries, FolderEntry};
 #[macro_use]
 mod macros;
 
+mod all_files;
 mod builder;
 mod cabinet;
 mod checksum;
@@ -115,4 +116,3 @@ mod file;
 mod folder;
 mod mszip;
 mod string;
-mod all_files;


### PR DESCRIPTION
Currently, there is no method to retrieve all files in the cabinet. Library users who want to extract all files need to iterate using Cabinet::read_file, which throws away bytes up to where the target file is located in the decompressed stream, which is inefficient.

This PR adds a new method Cabinet::all_files that returns an AllFiles struct. When library user repeatedly calls next_file method on it, it yields tuples of (file_entry, reader) for each file in the cabinet.

fixes #33 
fixes #24 