### PR TITLE
Fix panic on folders with zero data blocks

### DIFF
--- a/src/cabinet.rs
+++ b/src/cabinet.rs
@@ -247,7 +247,7 @@ impl<R: ?Sized + Seek> Seek for &CabinetInner<R> {
 
 #[cfg(test)]
 mod tests {
-    use std::io::{Cursor, Read};
+    use std::io::{self, Cursor, Read};
 
     use super::Cabinet;
 
@@ -413,6 +413,23 @@ mod tests {
         let mut data = Vec::new();
         cabinet.read_file("bye.txt").unwrap().read_to_end(&mut data).unwrap();
         assert_eq!(data, b"See you later!\r\n");
+    }
+
+    #[test]
+    fn read_cabinet_with_zero_data_blocks_returns_error() {
+        // Malformed CAB: one folder with num_data_blocks=0, one file entry
+        // with non-zero uncompressed_offset referencing that folder.
+        // This must return an io::Error, not panic with index out of bounds.
+        let binary: &[u8] = b"MSCF\0\0\0\0\x42\0\0\0\0\0\0\0\
+            \x2c\0\0\0\0\0\0\0\x03\x01\x01\0\x01\0\0\0\0\0\0\0\
+            \x42\0\0\0\x00\0\0\0\
+            \x0e\0\0\0\x01\0\0\0\0\0\x6c\x22\xba\x59\x01\0a.txt\0";
+        assert_eq!(binary.len(), 0x42);
+        let mut cabinet = Cabinet::new(Cursor::new(binary)).unwrap();
+        match cabinet.read_file("a.txt") {
+            Err(err) => assert_eq!(err.kind(), io::ErrorKind::InvalidData),
+            Ok(_) => panic!("expected InvalidData error"),
+        }
     }
 
     #[test]

--- a/src/folder.rs
+++ b/src/folder.rs
@@ -130,12 +130,18 @@ impl<'a, R: Read + Seek> FolderReader<'a, R> {
             self.rewind()?;
         }
         if new_offset > 0 {
+            if self.data_blocks.is_empty() {
+                invalid_data!("folder has no data blocks");
+            }
             // TODO: If folder is uncompressed, we should just jump straight to
             // the correct block without "decompressing" those in between.
             while self.data_blocks[self.current_block_index].cumulative_size
                 < new_offset
             {
                 self.current_block_index += 1;
+                if self.current_block_index >= self.num_data_blocks {
+                    invalid_data!("offset beyond available data blocks");
+                }
                 self.load_block()?;
             }
         }


### PR DESCRIPTION
## Summary

Fixes #37 -- `FolderReader::seek_to_uncompressed_offset` panics with "index out of bounds" when a malformed CAB file has a folder with `num_data_blocks == 0` but file entries that reference it with a non-zero uncompressed offset.

**Changes:**
- Add a bounds check before accessing `self.data_blocks[self.current_block_index]`: if `data_blocks` is empty, return `io::Error(InvalidData)` instead of panicking
- Add a bounds check after incrementing `self.current_block_index` in the seek loop: if the index exceeds `num_data_blocks`, return `io::Error(InvalidData)` instead of potentially panicking on subsequent iterations
- Add a test with a crafted malformed CAB binary (zero data blocks, non-zero file offset) that verifies the error is returned correctly

**Files changed:**
- `src/folder.rs` -- two bounds checks in `seek_to_uncompressed_offset`
- `src/cabinet.rs` -- one new test

All existing tests continue to pass.