### PR TITLE
Avoid panic when reading a file in a folder with no data blocks

### DIFF
--- a/src/cabinet.rs
+++ b/src/cabinet.rs
@@ -315,6 +315,28 @@ mod tests {
     }
 
     #[test]
+    fn read_file_in_folder_with_no_data_blocks() {
+        // Same cabinet as `read_uncompressed_cabinet_with_two_files`, but the
+        // folder is patched to claim zero data blocks. Reading `bye.txt`, whose
+        // entry starts at a nonzero offset within that folder, used to seek past
+        // the (empty) list of data blocks and panic with an out-of-bounds index.
+        let mut binary = b"MSCF\0\0\0\0\x80\0\0\0\0\0\0\0\
+            \x2c\0\0\0\0\0\0\0\x03\x01\x01\0\x02\0\0\0\x34\x12\0\0\
+            \x5b\0\0\0\x01\0\0\0\
+            \x0e\0\0\0\0\0\0\0\0\0\x6c\x22\xe7\x59\x01\0hi.txt\0\
+            \x0f\0\0\0\x0e\0\0\0\0\0\x6c\x22\xe7\x59\x01\0bye.txt\0\
+            \0\0\0\0\x1d\0\x1d\0Hello, world!\nSee you later!\n"
+            .to_vec();
+        // Clear the folder's num_data_blocks field.
+        binary[40] = 0;
+        let mut cabinet = Cabinet::new(Cursor::new(binary)).unwrap();
+
+        let mut data = Vec::new();
+        cabinet.read_file("bye.txt").unwrap().read_to_end(&mut data).unwrap();
+        assert!(data.is_empty());
+    }
+
+    #[test]
     fn read_uncompressed_cabinet_with_two_data_blocks() {
         let binary: &[u8] = b"MSCF\0\0\0\0\x61\0\0\0\0\0\0\0\
             \x2c\0\0\0\0\0\0\0\x03\x01\x01\0\x01\0\0\0\x34\x12\0\0\

--- a/src/folder.rs
+++ b/src/folder.rs
@@ -132,8 +132,9 @@ impl<'a, R: Read + Seek> FolderReader<'a, R> {
         if new_offset > 0 {
             // TODO: If folder is uncompressed, we should just jump straight to
             // the correct block without "decompressing" those in between.
-            while self.data_blocks[self.current_block_index].cumulative_size
-                < new_offset
+            while self.current_block_index < self.num_data_blocks
+                && self.data_blocks[self.current_block_index].cumulative_size
+                    < new_offset
             {
                 self.current_block_index += 1;
                 self.load_block()?;


### PR DESCRIPTION
Reading a file whose folder declares `num_data_blocks == 0` panics with an out-of-bounds index. The file entry can still carry a nonzero `uncompressed_offset`, so `seek_to_uncompressed_offset` walks the (empty) `data_blocks` list and indexes past its end.

This bounds the seek loop by `num_data_blocks` so it stops once there are no more blocks, matching the guard already used in `load_block`. The requested offset then lands past the folder data and reads return no bytes instead of panicking.

Added a regression test that reuses the existing two-file cabinet with the folder patched to zero data blocks.

Fixes #41.